### PR TITLE
v1.3.2: outcome-plot reversal-gap fix + dotted bridges for missing data

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,8 +1,8 @@
 Package: panelView
 Type: Package
 Title: Visualizing Panel Data
-Version: 1.3.1
-Date: 2026-05-13
+Version: 1.3.2
+Date: 2026-05-14
 Authors@R: 
   c(person("Yiqing", "Xu", ,"yiqingxu@stanford.edu", role = c("aut", "cre"), 
   comment = c(ORCID = "0000-0003-2041-6671")),

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,9 @@
+# panelView 1.3.2
+
+* Outcome plots: treated overlay no longer spans control intervals within a reversal unit.
+* Outcome plots under `leave.gap = FALSE`: gaps from dropped rows render as a dotted bridge instead of a solid interpolated line.
+* New tutorial section "Treatment reversal and missing data" with worked examples on `fect::sim_base`.
+
 # panelView 1.3.1
 
 ## Visual refresh

--- a/R/panelView.R
+++ b/R/panelView.R
@@ -896,7 +896,9 @@ panelview <- function(data, # a data frame (long-form)
         #     }
         # }
 
-        ## check DID mode
+        ## check DID mode -- classification is based on the OBSERVED rows
+        ## (cells with I == 1), so a unit whose early treated rows have
+        ## been dropped by na.omit is classified by its surviving pattern.
         if (sum(abs(D.old[which(I==1)] - D[which(I==1)]), na.rm = TRUE) == 0) {
             staggered <- 1
         } else { ## FE mode, with reversals
@@ -906,7 +908,7 @@ panelview <- function(data, # a data frame (long-form)
             if (by.cohort == TRUE) {
                 stop("option \"by.cohort = TRUE\" works only with staggered adoption.")
             }
-            }            
+            }
             staggered <- 0
         }
 

--- a/R/plot-outcome.R
+++ b/R/plot-outcome.R
@@ -1,7 +1,49 @@
+## Internal helper. Splits each (id, type) group of `data` into contiguous
+## "segments" of observed time and returns the bridge pairs that connect
+## consecutive non-adjacent observations. Used by the outcome plot to draw
+## a dotted bridge across interior gaps under `leave.gap = FALSE`, where
+## the missing rows have been dropped and `geom_line` would otherwise
+## interpolate a solid line across the gap.
+##
+## A "bridge" is a pair (prev_obs, this_obs) within the same (id, type)
+## group whose time difference exceeds `expected_step`. The returned
+## `data` carries a new `seg_id` column (constant within a contiguous
+## run, incrementing at each bridge) so callers can pass
+## `group = interaction(id, seg_id)` to `geom_line` and have the polyline
+## break at gaps; `bridges` is the per-pair data frame for `geom_segment`.
+.pv_segment_gaps <- function(data, expected_step) {
+    data <- data[order(data$id, data$type, data$time), , drop = FALSE]
+    grp <- paste(data$id, data$type, sep = "__")
+
+    prev_time    <- ave(data$time,    grp, FUN = function(t) c(NA, utils::head(t, -1)))
+    prev_outcome <- ave(data$outcome, grp, FUN = function(y) c(NA, utils::head(y, -1)))
+
+    bridge_mask <- !is.na(prev_time) &
+                   !is.na(data$outcome) &
+                   !is.na(prev_outcome) &
+                   (data$time - prev_time) > (expected_step + .Machine$double.eps)
+
+    data$seg_id <- ave(as.integer(bridge_mask), grp,
+                       FUN = function(x) cumsum(x) + 1L)
+
+    bridges <- if (any(bridge_mask)) {
+        data.frame(id   = data$id[bridge_mask],
+                   type = data$type[bridge_mask],
+                   x    = prev_time[bridge_mask],
+                   y    = prev_outcome[bridge_mask],
+                   xend = data$time[bridge_mask],
+                   yend = data$outcome[bridge_mask],
+                   stringsAsFactors = FALSE)
+    } else NULL
+
+    list(data = data, bridges = bridges)
+}
+
 .pv_subplot <- function(data, limits, colors, main, outcome.type, theme.bw,
                         xlab, ylab, angle, x.h, cex.main, raw.color,
                         show, T.b, time.label, ylim, set.labels) {
-                time <- outcome <- type <- id <- NULL  # suppress R CMD check note
+                time <- outcome <- type <- id <- seg_id <- NULL  # suppress R CMD check note
+                x <- y <- xend <- yend <- NULL  # geom_segment aesthetics
                 if (outcome.type == "discrete") {
                     data$outcome <- factor(data$outcome)
                     data <- na.omit(data)
@@ -35,15 +77,40 @@
 
                 ## main
                 if (outcome.type == "continuous") {
+                    ## Segment each (id, type) trajectory at gaps and overlay
+                    ## a dotted bridge across each gap. See the main reversal
+                    ## branch for rationale. Under leave.gap = TRUE this is a
+                    ## no-op (no bridges produced).
+                    expected.step <- {
+                        .ut <- sort(unique(data$time))
+                        if (length(.ut) >= 2) min(diff(.ut)) else 1
+                    }
+                    seg.out <- .pv_segment_gaps(data, expected.step)
+                    data    <- seg.out$data
+                    bridges <- seg.out$bridges
+
                     line.aes <- aes(time, outcome,
                                     colour = type,
                                     linewidth = type,
                                     linetype = type,
-                                    group = id)
+                                    group = interaction(id, seg_id))
                     for (.t in c("co", "tr", "tr.pst")) {
                         d.t <- data[data$type == .t, , drop = FALSE]
                         if (nrow(d.t) > 0) {
                             p <- p + geom_line(data = d.t, mapping = line.aes)
+                        }
+                        if (!is.null(bridges)) {
+                            b.t <- bridges[bridges$type == .t, , drop = FALSE]
+                            if (nrow(b.t) > 0) {
+                                p <- p + geom_segment(data = b.t,
+                                                      mapping = aes(x = x, y = y,
+                                                                    xend = xend,
+                                                                    yend = yend,
+                                                                    colour = type),
+                                                      linetype = "dotted",
+                                                      show.legend = FALSE,
+                                                      inherit.aes = FALSE)
+                            }
                         }
                     }
 
@@ -290,7 +357,7 @@
             if (outcome.type == "continuous") { ## continuous outcome
                 
                 if (staggered == 0 || (by.cohort == FALSE && pre.post == FALSE)) { ## with reversals
-                
+
                     D.plot <- D.old
                     D.plot[which(D.plot == 0)] <- NA
                     D.plot[which(I == 0)] <- NA
@@ -298,26 +365,24 @@
                     Y.trt <- Y * D.plot
                     Y.trt.show <- as.matrix(Y.trt[show,])
                     time.trt.show <- time[show]
-                    ut.time <- ut.id <- NULL
-                    for (i in 1:N) {
-                        if (sum(is.na(Y.trt.show[,i])) != nT) {
-                            ut.id <- c(ut.id, rep(i, nT - sum(is.na(Y.trt.show[,i]))))
-                            ut.time <- c(ut.time, time.trt.show[which(!is.na(Y.trt.show[,i]))])
-                        }
-                    }
-                    T1_0 <- c(T1)[which(T1==0)]
-                    T1_1 <- c(T1)[which(T1==1)]
-                    N_T1_1 <- sum(T1_1)
-                    N_T1_0 <- N*nT + length(ut.id) - N_T1_1
 
-                    data <- cbind.data.frame("time" = c(rep(time[show], N), ut.time),
-                                             "outcome" = c(c(Y[show,]),
-                                                         c(Y.trt.show[which(!is.na(Y.trt.show))])),
+                    ## Build the "tr" overlay on the FULL balanced panel for any
+                    ## unit with >=1 treated period, keeping NA at non-treated
+                    ## periods. geom_line breaks polylines at NA, so a unit
+                    ## with reversal (treated -> control -> treated) renders as
+                    ## two separate segments instead of one straight line that
+                    ## spans the control gap.
+                    treated.units <- which(colSums(!is.na(Y.trt.show)) > 0)
+                    n.tr.u  <- length(treated.units)
+                    tr.time    <- rep(time.trt.show, n.tr.u)
+                    tr.outcome <- c(Y.trt.show[, treated.units, drop = FALSE])
+                    tr.id      <- rep(treated.units, each = nT)
+
+                    data <- cbind.data.frame("time" = c(rep(time[show], N), tr.time),
+                                             "outcome" = c(c(Y[show,]), tr.outcome),
                                              "type" = c(rep("co",(N*nT)),
-                                                        rep("tr",length(ut.id))),
-                                            "last_dot" = c(rep("0",N_T1_0),
-                                                           rep("1",N_T1_1)),
-                                             "id" = c(rep(1:N,each = nT), ut.id))
+                                                        rep("tr", n.tr.u * nT)),
+                                             "id" = c(rep(1:N,each = nT), tr.id))
 
                     idtimes <- sapply(1:length(data$id),function(x)sum(data$id[1:x]==data$id[x]))
                     data <- cbind(data, idtimes)
@@ -544,17 +609,51 @@
                 ## main: draw controls first (bottom), then treated-pre, then
                 ## treated-post -- three separate layers because geom_line draws
                 ## polylines in group-value order, not row order.
+                ##
+                ## Under leave.gap = FALSE, the input is na.omit'd before the Y
+                ## matrix is built, so missing observations show up as time
+                ## gaps in `data` rather than NA outcome cells. The default
+                ## geom_line would then interpolate a solid line across those
+                ## gaps. We segment each (id, type) group at any gap larger
+                ## than the expected step, break the polyline there (via
+                ## group = interaction(id, seg_id)), and overlay a dotted
+                ## geom_segment as a visual marker that the bridge crosses
+                ## unobserved periods. Under leave.gap = TRUE, missing periods
+                ## are already NA cells, the polyline already breaks, and
+                ## bridges is empty so no segments are drawn.
+                expected.step <- {
+                    .ut <- sort(unique(time[show]))
+                    if (length(.ut) >= 2) min(diff(.ut)) else 1
+                }
+                seg.out <- .pv_segment_gaps(data, expected.step)
+                data    <- seg.out$data
+                bridges <- seg.out$bridges
+
                 spaghetti.alpha <- if (isTRUE(group.mean.overlay)) 0.18 else 1
                 line.aes <- aes(time, outcome,
                                 colour = type,
                                 linewidth = type,
                                 linetype = type,
-                                group = id)
+                                group = interaction(id, seg_id))
                 for (.t in c("co", "tr", "tr.pst")) {
                     d.t <- data[data$type == .t, , drop = FALSE]
                     if (nrow(d.t) > 0) {
                         p <- p + geom_line(data = d.t, mapping = line.aes,
                                            alpha = spaghetti.alpha)
+                    }
+                    if (!is.null(bridges)) {
+                        b.t <- bridges[bridges$type == .t, , drop = FALSE]
+                        if (nrow(b.t) > 0) {
+                            p <- p + geom_segment(data = b.t,
+                                                  mapping = aes(x = x, y = y,
+                                                                xend = xend,
+                                                                yend = yend,
+                                                                colour = type),
+                                                  linetype = "dotted",
+                                                  alpha = spaghetti.alpha,
+                                                  show.legend = FALSE,
+                                                  inherit.aes = FALSE)
+                        }
                     }
                 }
 
@@ -760,27 +859,21 @@
                     Y.trt <- Y.rv * D.rv
                     Y.trt.show <- as.matrix(Y.trt[show,])
                     time.trt.show <- time[show]
-                    ut.time <- ut.id <- NULL
-                    for (i in 1:Nrv) {
-                        if (sum(is.na(Y.trt.show[,i])) != nT) {
-                            ut.id <- c(ut.id, rep(i, nT - sum(is.na(Y.trt.show[,i]))))
-                            ut.time <- c(ut.time, time.trt.show[which(!is.na(Y.trt.show[,i]))])
-                        }
-                    }
 
-                    T1_0 <- c(T1)[which(T1==0)]
-                    T1_1 <- c(T1)[which(T1==1)]
-                    N_T1_1 <- sum(T1_1)
-                    N_T1_0 <- Nrv*nT + length(ut.id) - N_T1_1
+                    ## See "with reversals" branch above: keep the balanced
+                    ## panel with NA at non-treated periods so geom_line breaks
+                    ## the polyline at control gaps within a reversal unit.
+                    treated.units <- which(colSums(!is.na(Y.trt.show)) > 0)
+                    n.tr.u  <- length(treated.units)
+                    tr.time    <- rep(time.trt.show, n.tr.u)
+                    tr.outcome <- c(Y.trt.show[, treated.units, drop = FALSE])
+                    tr.id      <- rep(treated.units, each = nT)
 
-                    data3 <- cbind.data.frame("time" = c(rep(time[show], Nrv), ut.time),
-                                              "outcome" = c(c(Y[show, rv.pos]),
-                                                          c(Y.trt.show[which(!is.na(Y.trt.show))])),
+                    data3 <- cbind.data.frame("time" = c(rep(time[show], Nrv), tr.time),
+                                              "outcome" = c(c(Y[show, rv.pos]), tr.outcome),
                                               "type" = c(rep("co",(Nrv*nT)),
-                                                       rep("tr",length(ut.id))),
-                                              "last_dot" = c(rep("0",N_T1_0),
-                                                             rep("1",N_T1_1)),
-                                              "id" = c(rep(1:Nrv,each = nT), ut.id))
+                                                       rep("tr", n.tr.u * nT)),
+                                              "id" = c(rep(1:Nrv,each = nT), tr.id))
 
                     data3_tr <- subset(data3, data3$type=="tr")  
                     data3_co <- subset(data3, data3$type=="co") 
@@ -794,6 +887,7 @@
                     idtimes <- sapply(1:length(data3_co$id),function(x)sum(data3_co$id[1:x]==data3_co$id[x]))
                     data3_co <- cbind(data3_co, idtimes)
                     data3_co$idtimes <- ave(data3_co$idtimes, data3_co$id, FUN=max)
+                    data3_co$last_dot <- 0
 
                     data3 <- rbind(data3_co,data3_tr)
 

--- a/tutorial/02-outcome.Rmd
+++ b/tutorial/02-outcome.Rmd
@@ -149,6 +149,111 @@ panelview(Y = "turnout", data = turnout,
           xlab = "Year", ylab = "Turnout")
 ```
 
+## Treatment reversal and missing data {#sec-outcome-reversal}
+
+How **panelView** handles two common discontinuities in the outcome
+trajectory:
+
+- **Treatment reversal** (unit goes on then off, or off then on). The
+  treated overlay is drawn only at periods the unit is treated, so each
+  treated spell is a separate line segment.
+- **Missing outcome**. Under the default `leave.gap = FALSE`, rows with
+  missing `Y` are dropped and the bracketing observed points are joined
+  by a **dotted** segment so the gap is visible. Under `leave.gap = TRUE`
+  the panel is expanded and the line breaks cleanly at every NA cell.
+
+Topology classification (reversal vs. staggered) follows the observed
+data: if a unit's leading treated rows are missing and the surviving
+`D` pattern is monotonic, the unit is plotted in the staggered palette.
+
+Examples below use `fect::sim_base`. Unit 102 is treated at $t=1\!-\!3$,
+control at $t=4\!-\!26$, then treated at $t=27\!-\!35$.
+
+### Reversal alone
+
+```{r outcome-reversal, fig.height=4.2}
+if (requireNamespace("fect", quietly = TRUE)) {
+  data("sim_base", package = "fect")
+  panelview(Y ~ D, data = subset(sim_base, id == 102),
+            index = c("id", "time"), type = "outcome",
+            main = "Unit 102: treated 1-3, control 4-26, treated 27-35")
+}
+```
+
+### Interior gap: dotted bridge under `leave.gap = FALSE`
+
+Set $Y$ to `NA` at $t=10\!-\!12$ and $t=30\!-\!31$. The control line
+shows a dotted bridge between $t=9$ and $t=13$; the treated line shows
+one between $t=29$ and $t=32$.
+
+```{r outcome-missing-default, fig.height=4.2}
+if (requireNamespace("fect", quietly = TRUE)) {
+  d <- subset(sim_base, id == 102)
+  d$Y[d$time %in% c(10, 11, 12)] <- NA
+  d$Y[d$time %in% c(30, 31)]     <- NA
+  panelview(Y ~ D, data = d, index = c("id", "time"),
+            type = "outcome",
+            main = "leave.gap = FALSE: dotted bridge across missing periods")
+}
+```
+
+### Interior gap: clean break under `leave.gap = TRUE`
+
+Same data, but `leave.gap = TRUE` keeps the NA rows, so the line breaks
+at every gap with no bridge.
+
+```{r outcome-missing-leave-gap, fig.height=4.2}
+if (requireNamespace("fect", quietly = TRUE)) {
+  d <- subset(sim_base, id == 102)
+  d$Y[d$time %in% c(10, 11, 12)] <- NA
+  d$Y[d$time %in% c(30, 31)]     <- NA
+  panelview(Y ~ D, data = d, index = c("id", "time"),
+            type = "outcome", leave.gap = TRUE,
+            main = "leave.gap = TRUE: line breaks at gaps, no bridge")
+}
+```
+
+### Missing at the boundary
+
+Drop unit 102's $Y$ at $t=1\!-\!3$ (the start of its series) and pass
+`leave.gap = TRUE` so the row is retained, the x-axis stays at
+$t=1\!-\!35$, and the topology classifier still sees the early
+treated $D$ values. The line is empty at $t=1\!-\!3$; everything else
+is unchanged.
+
+```{r outcome-missing-boundary, fig.height=4.2}
+if (requireNamespace("fect", quietly = TRUE)) {
+  d <- subset(sim_base, id == 102)
+  d$Y[d$time %in% 1:3] <- NA
+  panelview(Y ~ D, data = d, index = c("id", "time"),
+            type = "outcome", leave.gap = TRUE,
+            main = "Drop Y at t=1-3 (leave.gap = TRUE keeps x-axis and classification)")
+}
+```
+
+Under the default `leave.gap = FALSE`, the same NA injection drops
+those rows entirely. The panel for this unit shrinks to $t=4\!-\!35$,
+its surviving $D$ pattern becomes monotonic, and the classifier
+re-types it as staggered. Use `leave.gap = TRUE` whenever you need
+the boundary intact.
+
+### `by.group = TRUE` with all three subpanels
+
+`by.group = TRUE` splits units by their treatment history: always under
+control, always under treatment, and treatment status changed. To
+exercise all three subpanels we promote one `sim_base` unit to
+always-treated.
+
+```{r outcome-bygroup-full, fig.height=8}
+if (requireNamespace("fect", quietly = TRUE)) {
+  d <- sim_base
+  d$D[d$id == 101] <- 1    ## promote unit 101 to always-treated
+  panelview(Y ~ D, data = d, index = c("id", "time"),
+            type = "outcome", by.group = TRUE,
+            main = "by.group = TRUE: always control / always treated / status changed")
+}
+```
+
 ## Discrete outcomes
 
 Set `outcome.type = "discrete"` when the outcome takes a small number of integer values.

--- a/tutorial/aa-changelog.Rmd
+++ b/tutorial/aa-changelog.Rmd
@@ -1,5 +1,13 @@
 # Changelog {#sec-changelog .unnumbered}
 
+## v1.3.2
+
+(2026-05-14)
+
+* Outcome plots: treated overlay no longer spans control intervals within a reversal unit (each treated spell renders as its own segment).
+* Outcome plots under `leave.gap = FALSE`: gaps from dropped rows are now drawn as a dotted bridge instead of a solid interpolated line.
+* New tutorial section "Treatment reversal and missing data" with worked examples on `fect::sim_base`.
+
 ## v1.3.1
 
 (2026-05-13)

--- a/tutorial/index.qmd
+++ b/tutorial/index.qmd
@@ -8,7 +8,7 @@ This manual serves as a user guide for the **panelView** package in R, which vis
 |--------|---------|------|----------|
 | CRAN | 1.3.1 | 2026-05-13 | Refreshed plot defaults; `type = "network"`; `theme = "red"`; `group.mean.overlay` |
 | GitHub (`master`) | 1.3.1 | 2026-05-13 | Same as CRAN |
-| GitHub (`dev`) | 1.3.1 | 2026-05-13 | Same as CRAN |
+| GitHub (`dev`) | 1.3.2 | 2026-05-14 | + reversal-gap fix; dotted bridges for missing observations under `leave.gap = FALSE` |
 
 ```{r install-cran, eval = FALSE}
 # From CRAN (stable release)


### PR DESCRIPTION
## Summary

- Treated overlay in outcome plots no longer spans control intervals within a reversal unit (each contiguous treated spell renders as its own segment). Affects `by.group=FALSE` and `by.group=TRUE`, both themes.
- Under default `leave.gap = FALSE`, observations bracketing a dropped row now connect via a **dotted** segment rather than a solid interpolated line. New internal helper `.pv_segment_gaps()` + geom_segment overlay. Bridges belong to the gray full-panel layer; the treated layer breaks at any status transition because one of its endpoints across the gap is NA.
- Under `leave.gap = TRUE`, polylines simply break at NA cells — no bridge.
- Reversal vs. staggered classification is intentionally based on the *observed* surviving rows: a unit whose early treated periods have missing `Y` under `leave.gap = FALSE` is plotted in the staggered palette, since that is the only classification supported by the remaining data. Pass `leave.gap = TRUE` to preserve the reversal classification when `Y` is missing but `D` is not.

## Tutorial

New section "Treatment reversal and missing data" in the Outcome Trajectories chapter with worked examples using `fect::sim_base`:
- Reversal alone (unit 102: treated 1-3, control 4-26, treated 27-35).
- Interior gap under `leave.gap = FALSE` showing dotted bridges.
- Interior gap under `leave.gap = TRUE` showing clean breaks.
- Boundary missingness with `leave.gap = TRUE` preserving the x-axis and binary palette.
- `by.group = TRUE` with all three subpanels populated (one unit promoted to always-treated).

## Test plan

- [x] `devtools::test()`: 116 PASS, 0 FAIL
- [x] `R CMD check`: code-related notes clean
- [x] Demo battery at `/tmp/pv_test/` (reversal, missing, edges, transitions, bridge color cases) re-rendered and visually verified
- [x] `quarto render` succeeds for all 7 chapters
- [x] Reviewer: spot-check the new tutorial section figures
- [x] Reviewer: confirm 1.3.2 framing is acceptable for the next CRAN release

DESCRIPTION bumped to 1.3.2 / 2026-05-14. NEWS.md and tutorial changelog updated (3 one-line bullets each).

🤖 Generated with [Claude Code](https://claude.com/claude-code)