### PR TITLE
feat: sample = overlay + panelview(fit) entry-point + PanelMatch integration (v1.3.3)

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,8 +1,8 @@
 Package: panelView
 Type: Package
 Title: Visualizing Panel Data
-Version: 1.3.2
-Date: 2026-05-14
+Version: 1.3.3
+Date: 2026-05-19
 Authors@R: 
   c(person("Yiqing", "Xu", ,"yiqingxu@stanford.edu", role = c("aut", "cre"), 
   comment = c(ORCID = "0000-0003-2041-6671")),

--- a/NAMESPACE
+++ b/NAMESPACE
@@ -2,6 +2,7 @@
 ##exportPattern("^[[:alpha:]]+")
 importFrom("stats", "na.omit", "sd", "var", "ave", "aggregate", "approxfun",
            "setNames")
+importFrom("utils", "head")
 importFrom("ggplot2", "geom_boxplot", "geom_density", "geom_tile",
            "geom_point","geom_col", "labs", "theme_bw", "scale_fill_manual",
            "geom_hline", "geom_line", "geom_ribbon", "geom_vline",
@@ -20,3 +21,4 @@ importFrom("grid", "textGrob", "gpar")
 importFrom("dplyr", "coalesce", "summarise", "group_by_all", "n")
 
 export(panelview)
+export(panelmatch_to_sample)

--- a/R/fit_to_panel.R
+++ b/R/fit_to_panel.R
@@ -1,0 +1,179 @@
+# Reconstruct the (data, formula, index) triple that panelview()
+# needs from a fitted panel-estimator object. Supported classes:
+#
+#   fect, gsynth, tjbal --- carry $Y.dat, $D.dat, $index, $Y, $D
+#                           (T x N matrices keyed on (time, unit))
+#   cip                 --- carries $Y_mat, $D_mat (N x T), $unit_levels,
+#                           $time_levels, $index_names (or implicit)
+#
+# Returned list always has:
+#   data    : long-format data.frame with three columns matching the
+#             original (unit, time) names plus Y, D
+#   formula : Y ~ D
+#   index   : c(unit_name, time_name)
+.pv_from_fit <- function(fit, envir = parent.frame()) {
+
+    if (inherits(fit, "fect") ||
+        inherits(fit, "gsynth") ||
+        inherits(fit, "tjbal") ||
+        inherits(fit, "cip")) {
+
+        ## Preferred path 1: the fit object carries the original input
+        ## long-format data ($data.long). Use it as-is --- this preserves
+        ## the full pre-drop panel including units the estimator removed,
+        ## which then render as "Not used" cells under the mask.
+        if (!is.null(fit$data.long) && is.data.frame(fit$data.long) &&
+            !is.null(fit$index) && length(fit$index) >= 2L &&
+            !is.null(fit$Y) && !is.null(fit$D)) {
+            unit_name <- fit$index[1L]
+            time_name <- fit$index[2L]
+            Y_name    <- fit$Y
+            D_name    <- fit$D
+            return(list(
+                data    = fit$data.long,
+                formula = stats::as.formula(paste0(Y_name, " ~ ", D_name)),
+                index   = c(unit_name, time_name),
+                sample  = fit$sample
+            ))
+        }
+
+        ## Preferred path 2: evaluate fit$call$data in the user's
+        ## calling environment to recover the original data.frame. This
+        ## restores the FULL pre-drop panel --- units the estimator
+        ## dropped (always-treated, insufficient pre-period, etc.) show
+        ## up with their original (unit, time, Y, D) values and get
+        ## flagged "Not used" by fit$sample. Falls through silently if
+        ## the data symbol is not in scope or doesn't yield a usable
+        ## data.frame with the expected columns.
+        if (!is.null(fit$call) && !is.null(fit$call$data) &&
+            !is.null(fit$index) && length(fit$index) >= 2L &&
+            !is.null(fit$Y) && !is.null(fit$D)) {
+            unit_name <- fit$index[1L]
+            time_name <- fit$index[2L]
+            Y_name    <- fit$Y
+            D_name    <- fit$D
+            orig <- tryCatch(eval(fit$call$data, envir = envir),
+                             error = function(e) NULL)
+            if (is.data.frame(orig) &&
+                all(c(unit_name, time_name, Y_name, D_name) %in%
+                    names(orig))) {
+                return(list(
+                    data    = as.data.frame(orig),
+                    formula = stats::as.formula(paste0(Y_name, " ~ ",
+                                                        D_name)),
+                    index   = c(unit_name, time_name),
+                    sample  = fit$sample
+                ))
+            }
+        }
+
+        ## Fallback: reconstruct from the post-drop matrices. The mask
+        ## is subset to the kept-unit set so the strict alignment guard
+        ## passes; dropped units do not appear in the figure.
+        Y_mat <- fit$Y.dat
+        D_mat <- fit$D.dat
+        if (is.null(Y_mat) || is.null(D_mat)) {
+            stop("Fitted object does not carry $Y.dat / $D.dat; ",
+                 "panelview cannot reconstruct the panel automatically. ",
+                 "Pass `data`, `formula`, `index` explicitly.",
+                 call. = FALSE)
+        }
+        TT    <- nrow(Y_mat)
+        N     <- ncol(Y_mat)
+        ## Y.dat / D.dat may carry no dimnames (fect's case); fall back to
+        ## $id (length N) and $rawtime (length T) which fect always sets.
+        units <- colnames(Y_mat)
+        if (is.null(units) || length(units) != N) units <- fit$id
+        if (is.null(units) || length(units) != N) units <- seq_len(N)
+
+        times_raw <- rownames(Y_mat)
+        if (is.null(times_raw) || length(times_raw) != TT)
+            times_raw <- fit$rawtime
+        if (is.null(times_raw) || length(times_raw) != TT)
+            times_raw <- seq_len(TT)
+        times_num <- suppressWarnings(as.numeric(times_raw))
+        times <- if (!anyNA(times_num)) times_num else times_raw
+
+        unit_name <- if (!is.null(fit$index) && length(fit$index) >= 1L)
+            fit$index[1L] else "unit"
+        time_name <- if (!is.null(fit$index) && length(fit$index) >= 2L)
+            fit$index[2L] else "time"
+        Y_name <- if (!is.null(fit$Y)) fit$Y else "Y"
+        D_name <- if (!is.null(fit$D)) fit$D else "D"
+
+        long <- data.frame(
+            ..unit = rep(units, each = TT),
+            ..time = rep(times, times = N),
+            ..Y    = as.vector(Y_mat),
+            ..D    = as.vector(D_mat),
+            stringsAsFactors = FALSE
+        )
+        ## restore original column names
+        names(long) <- c(unit_name, time_name, Y_name, D_name)
+
+        ## Restore the original missing-cell pattern. fect (and
+        ## relatives) fill in `Y.dat` / `D.dat` after na.rm = TRUE, so
+        ## cells that were NA in the source data appear as observed
+        ## values in the reconstructed long-form data above. Without
+        ## intervention, panelview() would shade those cells in the
+        ## active palette (and the sample-mask overlay would relabel
+        ## them as "Not used") instead of keeping them as Missing.
+        ## fect's `$I` matrix is the observed indicator (1 = observed,
+        ## 0 = missing); aligned to `$Y.dat` columns. Use it to set
+        ## Y / D back to NA in the reconstructed data.
+        I_mat <- fit$I
+        if (!is.null(I_mat) && is.matrix(I_mat) &&
+            identical(dim(I_mat), dim(Y_mat))) {
+            miss <- as.vector(I_mat) == 0
+            long[[Y_name]][miss] <- NA
+            long[[D_name]][miss] <- NA
+        }
+
+        ## panelview's leave.gap = TRUE path drops units that have at
+        ## least one all-NA column. Pre-drop those here so the
+        ## reconstructed long-form data and the returned $sample have
+        ## matching unit sets (otherwise the strict alignment guard
+        ## fires after panelview's drop).
+        all_na_units <- character(0)
+        for (u in unique(long[[unit_name]])) {
+            yi <- long[long[[unit_name]] == u, Y_name]
+            di <- long[long[[unit_name]] == u, D_name]
+            if (anyNA(yi) || anyNA(di)) {
+                ## panelview's check is per-row anyNA --- conservatively
+                ## drop units with any NA in either Y or D
+                if (all(is.na(yi)) || all(is.na(di))) {
+                    all_na_units <- c(all_na_units, as.character(u))
+                }
+            }
+        }
+        if (length(all_na_units) > 0) {
+            long <- long[!as.character(long[[unit_name]]) %in% all_na_units, ,
+                         drop = FALSE]
+        }
+
+        ## fect's $sample is sized on the pre-drop panel (matches
+        ## $obs.missing). The reconstructed long-form data above uses
+        ## the post-drop unit set ($id / Y.dat columns) and we just
+        ## dropped any further all-NA units. Subset $sample to match.
+        sample_out <- fit$sample
+        if (!is.null(sample_out)) {
+            if (!is.null(colnames(sample_out))) {
+                surviving <- setdiff(as.character(units), all_na_units)
+                keep <- as.character(colnames(sample_out)) %in% surviving
+                sample_out <- sample_out[, keep, drop = FALSE]
+            } else if (ncol(sample_out) != N - length(all_na_units)) {
+                sample_out <- NULL
+            }
+        }
+
+        return(list(
+            data    = long,
+            formula = stats::as.formula(paste0(Y_name, " ~ ", D_name)),
+            index   = c(unit_name, time_name),
+            sample  = sample_out
+        ))
+    }
+
+    stop("Unsupported fit class: ", paste(class(fit), collapse = "/"),
+         ". Pass `data`, `formula`, `index` explicitly.", call. = FALSE)
+}

--- a/R/panelView.R
+++ b/R/panelView.R
@@ -55,6 +55,8 @@ panelview <- function(data, # a data frame (long-form)
                       collapse.history = NULL,
                       report.missing = FALSE,
                       show.singletons = TRUE,
+                      sample = NULL,
+                      sample.sort = FALSE,
                       highlight.components = TRUE,
                       layout = "fr",
                       node.size = 3,
@@ -68,6 +70,20 @@ panelview <- function(data, # a data frame (long-form)
     ## ------------------------- ##
     ## parse variable.           ##
     ## ------------------------- ##
+
+    ## Fit-as-input dispatch. If the user passes a fitted fect / gsynth /
+    ## tjbal / cip object as the first argument, reconstruct `data`,
+    ## `formula`, and `index` from the fit and auto-pull `$sample`. This
+    ## removes the data-consistency burden: panelview plots the same
+    ## panel the estimator saw, period.
+    if (inherits(data, c("fect", "gsynth", "tjbal", "cip"))) {
+        fit <- data
+        recon <- .pv_from_fit(fit, envir = parent.frame())
+        data    <- recon$data
+        if (is.null(formula)) formula <- recon$formula
+        if (missing(index) || is.null(index)) index <- recon$index
+        if (is.null(sample) && !is.null(recon$sample)) sample <- recon$sample
+    }
 
     if (is.data.frame(data) == FALSE || length(class(data)) > 1) {
         data <- as.data.frame(data)
@@ -191,9 +207,27 @@ panelview <- function(data, # a data frame (long-form)
             stop("\"axis.lab.angle\" must be numeric.")
         } else if (axis.lab.angle < 0 | axis.lab.angle > 90) {
             stop("\"axis.lab.angle\" needs to be in [0, 90].")
-        } 
+        }
     }
-    
+
+    ## validate sample (logical matrix marking cells used in estimation;
+    ## also accepts a fitted fect/gsynth/tjbal/cip object with a $sample
+    ## field, or a PanelMatch object --- in which case `data` is also
+    ## consulted to define the panel axes).
+    if (!is.null(sample)) {
+        if (inherits(sample, c("fect", "gsynth", "tjbal", "cip"))) {
+            if (is.null(sample$sample)) {
+                stop("The fitted object passed to \"sample\" has no $sample field. Update to a package version that exposes it.")
+            }
+            sample <- sample$sample
+        } else if (inherits(sample, "PanelMatch")) {
+            sample <- panelmatch_to_sample(sample, data)
+        }
+        if (!is.matrix(sample) || !is.logical(sample)) {
+            stop("\"sample\" must be a logical matrix (or a fitted fect/gsynth/tjbal/cip / PanelMatch object).")
+        }
+    }
+
     # pre.post
     if (is.null(pre.post) == TRUE) {
         if (type == "outcome") {
@@ -667,10 +701,78 @@ panelview <- function(data, # a data frame (long-form)
     ## raw id and time
     raw.id <- sort(unique(data[,index[1]]))
     raw.time <- sort(unique(data[,index[2]]))
-    N <- length(raw.id) 
+    N <- length(raw.id)
     TT <- length(raw.time)
 
-    ## id to be plotted 
+    ## sample column alignment. Panel internals will index columns by
+    ## sort(unique(unit_id)) (factor-level order). If the supplied sample
+    ## has column names, permute its columns to match raw.id before any
+    ## other sample-related logic runs. Without this, a sample matrix whose
+    ## columns are in a different order silently lines cells up against
+    ## the wrong units.
+    ##
+    ## A sample matrix may legitimately carry extra columns for units that
+    ## panelview has already dropped (units with all-NA Y / D / X, dropped
+    ## above when leave.gap = 1). Those are silently subset out. The hard
+    ## error is for the other direction --- a unit panelview will plot but
+    ## the sample has no column for, which would silently leave that unit
+    ## un-included.
+    ## Alignment. When `sample` has dimnames we match by name. Two
+    ## directions of mismatch get different treatment:
+    ##   - Units / times in DATA but not in SAMPLE: fill with FALSE (the
+    ##     estimator never touched them, which is correct semantically).
+    ##     This is the "fit on a subset, view on the full panel" workflow.
+    ##   - Units / times in SAMPLE but not in DATA: error. The sample
+    ##     carries cells panelview cannot plot, so these are stale or
+    ##     misaligned and we cannot render them honestly.
+    if (!is.null(sample) && !is.null(colnames(sample))) {
+        sample_cols <- as.character(colnames(sample))
+        target      <- as.character(raw.id)
+        extra   <- setdiff(sample_cols, target)
+        if (length(extra) > 0) {
+            stop("\"sample\" has columns for ", length(extra),
+                 " unit(s) not in the data panelview will plot: ",
+                 paste(head(extra, 10), collapse = ", "),
+                 if (length(extra) > 10) ", ..." else "",
+                 ". Refit on the same data, or drop these columns ",
+                 "from `sample`.", call. = FALSE)
+        }
+        missing <- setdiff(target, sample_cols)
+        if (length(missing) > 0) {
+            pad <- matrix(FALSE, nrow = nrow(sample), ncol = length(missing),
+                          dimnames = list(rownames(sample), missing))
+            sample <- cbind(sample, pad)
+        }
+        sample <- sample[, match(target, colnames(sample)), drop = FALSE]
+    }
+
+    if (!is.null(sample) && !is.null(rownames(sample))) {
+        sample_rows <- as.character(rownames(sample))
+        target_t    <- as.character(raw.time)
+        extra_t   <- setdiff(sample_rows, target_t)
+        if (length(extra_t) > 0) {
+            stop("\"sample\" has rows for ", length(extra_t),
+                 " time period(s) not in the data panelview will plot: ",
+                 paste(head(extra_t, 10), collapse = ", "),
+                 if (length(extra_t) > 10) ", ..." else "",
+                 ". Refit on the same data, or drop these rows ",
+                 "from `sample`.", call. = FALSE)
+        }
+        missing_t <- setdiff(target_t, sample_rows)
+        if (length(missing_t) > 0) {
+            pad <- matrix(FALSE, nrow = length(missing_t), ncol = ncol(sample),
+                          dimnames = list(missing_t, colnames(sample)))
+            sample <- rbind(sample, pad)
+        }
+        sample <- sample[match(target_t, rownames(sample)), , drop = FALSE]
+    }
+
+    ## sample.sort.ord placeholder; the actual sort decision is made later,
+    ## once D and obs.missing are fully built (see the "compute + apply
+    ## sample.sort.ord" block right before plot dispatch).
+    sample.sort.ord <- NULL
+
+    ## id to be plotted
     input.id <- NULL
     if (!is.null(id)) {
         if (!is.null(show.id)) {
@@ -1254,6 +1356,78 @@ else if (leave.gap == 1) {
         legend.pos <- "none"
     } else {
         legend.pos <- "bottom"
+    }
+
+    ###########################
+    ## Compute sample.sort.ord from the (sample.sort, by.timing) flags.
+    ## Two binary knobs combine as primary/secondary sort keys:
+    ##   sample.sort = TRUE  --- in-sample units (colSums(sample) > 0) above
+    ##                          out-of-sample units (primary key)
+    ##   by.timing   = TRUE  --- first treatment period ascending within
+    ##                          each group (secondary key)
+    ## Either alone gives a single-key sort. Both off = no reorder.
+    ## When sample.sort.ord is set, plot-treat.R's by.timing reorder is
+    ## suppressed below.
+    ###########################
+    if (isTRUE(sample.sort) && is.null(sample)) {
+        warning("`sample.sort = TRUE` requires `sample` to be supplied; ",
+                "ignored.", call. = FALSE)
+        sample.sort <- FALSE
+    }
+    do_sort <- (isTRUE(sample.sort) || isTRUE(by.timing)) && is.matrix(D)
+    if (do_sort) {
+        if (!is.null(sample) &&
+            !identical(as.character(colnames(sample)),
+                       as.character(raw.id))) {
+            warning("\"sample\" column names do not match raw.id at sort ",
+                    "time; sample.sort skipped.")
+        } else {
+            t0_per <- apply(D, 2, function(d) {
+                k <- which(d == 1L)
+                if (length(k) == 0L) Inf else k[1]
+            })
+            keys <- list()
+            if (isTRUE(sample.sort)) {
+                in_sample <- colSums(sample) > 0
+                keys <- c(keys, list(!in_sample))
+            }
+            if (isTRUE(by.timing)) {
+                keys <- c(keys, list(t0_per))
+            }
+            sample.sort.ord <- do.call(order, keys)
+        }
+    }
+
+    if (!is.null(sample.sort.ord)) {
+        ord <- sample.sort.ord
+        if (!is.null(obs.missing)   && is.matrix(obs.missing))
+            obs.missing   <- obs.missing[, ord, drop = FALSE]
+        if (exists("obs.missing.balance") && is.matrix(obs.missing.balance))
+            obs.missing.balance <- obs.missing.balance[, ord, drop = FALSE]
+        if (!is.null(D)             && is.matrix(D))
+            D     <- D[, ord, drop = FALSE]
+        if (exists("D.old") && !is.null(D.old) && is.matrix(D.old))
+            D.old <- D.old[, ord, drop = FALSE]
+        if (!is.null(I)             && is.matrix(I))
+            I     <- I[, ord, drop = FALSE]
+        if (!is.null(Y)             && is.matrix(Y))
+            Y     <- Y[, ord, drop = FALSE]
+        if (!is.null(M)             && is.matrix(M))
+            M     <- M[, ord, drop = FALSE]
+        if (!is.null(sample))
+            sample <- sample[, ord, drop = FALSE]
+        if (!is.null(id))
+            id    <- id[ord]
+        if (exists("unit.type") && !is.null(unit.type))
+            unit.type <- unit.type[ord]
+        if (exists("T0")        && !is.null(T0)        && length(T0) == length(ord))
+            T0 <- T0[ord]
+        if (exists("co.total")  && !is.null(co.total)  && length(co.total) == length(ord))
+            co.total <- co.total[ord]
+        ## Suppress plot-treat.R's by.timing reorder so it doesn't re-sort
+        ## on top of the sample.sort ordering. by.timing's intent is already
+        ## baked into the "in.sample" / "type" sort modes when relevant.
+        by.timing <- FALSE
     }
 
     ###########################

--- a/R/panelmatch_to_sample.R
+++ b/R/panelmatch_to_sample.R
@@ -1,0 +1,190 @@
+## Project a PanelMatch matched-set object onto a logical T x N sample
+## mask that panelview() can render via `sample=`. Reads only the public
+## slots / attributes of a `PanelMatch` object --- no PanelMatch package
+## modification required.
+
+#' Convert a PanelMatch object to a panelView sample mask
+#'
+#' Walks a `PanelMatch` object's matched sets and returns a logical
+#' T x N matrix marking cells used in estimation, suitable for passing
+#' as `sample=` to \code{\link{panelview}}. For every treated event,
+#' the treated unit and each matched control (positive weight) are
+#' marked TRUE over `[t-lag, t+max(lead)]` --- the lag window covers
+#' the matching support and the lead window covers the outcome leads
+#' PanelMatch uses on the LHS, so within each event the light-blue
+#' pre-period and dark-blue post-onset cells render as one contiguous
+#' band.
+#'
+#' @param pm A `PanelMatch` object (from CRAN package PanelMatch).
+#' @param pd The `PanelData` object passed to `PanelMatch()`, or any
+#'   data.frame with the same `unit.id` and `time.id` columns. Used
+#'   only to define the panel axes (sorted unique units / times).
+#' @param qoi One of "att", "atc". If NULL and `pm` has a single
+#'   matched-set list, that one is used; if both are present "att"
+#'   is preferred.
+#' @param include Character vector. Any of "treated" (the treated unit
+#'   for each event) and "controls" (matched controls). Default both.
+#' @param weight.threshold Numeric. Controls with weight strictly
+#'   greater than this are marked. Default 0 keeps any positive weight.
+#'
+#' @return A logical matrix with rows = sorted unique times (rownames
+#'   are character), columns = sorted unique units (colnames are
+#'   character). TRUE = cell appears in at least one matched set.
+#'
+#' @examples
+#' \dontrun{
+#' library(PanelMatch)
+#' data(dem)
+#' pd <- PanelData(panel.data = dem, unit.id = "wbcode2",
+#'                 time.id = "year", treatment = "dem", outcome = "y")
+#' pm <- PanelMatch(panel.data = pd, lag = 4,
+#'                  refinement.method = "mahalanobis",
+#'                  covs.formula = ~ I(lag(tradewb, 1:4)),
+#'                  qoi = "att", lead = 0:3, match.missing = TRUE)
+#' mask <- panelmatch_to_sample(pm, pd)
+#' panelview(pd, formula = y ~ dem, index = c("wbcode2", "year"),
+#'           type = "treat", sample = mask)
+#' ## or just:
+#' panelview(pd, formula = y ~ dem, index = c("wbcode2", "year"),
+#'           type = "treat", sample = pm)
+#' }
+#' @export
+panelmatch_to_sample <- function(pm, pd,
+                                  qoi = NULL,
+                                  include = c("treated", "controls"),
+                                  weight.threshold = 0) {
+
+    if (!inherits(pm, "PanelMatch")) {
+        stop("`pm` must be a PanelMatch object.", call. = FALSE)
+    }
+    include <- match.arg(include, c("treated", "controls"),
+                        several.ok = TRUE)
+
+    ## Resolve unit.id / time.id from PanelMatch attributes first,
+    ## then PanelData attributes as fallback.
+    a_pm <- attributes(pm)
+    a_pd <- attributes(pd)
+    unit_id <- a_pm$unit.id %||% a_pd$unit.id
+    time_id <- a_pm$time.id %||% a_pd$time.id
+    if (is.null(unit_id) || is.null(time_id)) {
+        stop("Cannot resolve `unit.id` / `time.id` from `pm` or `pd` ",
+             "attributes.", call. = FALSE)
+    }
+    if (!unit_id %in% names(pd) || !time_id %in% names(pd)) {
+        stop("`pd` is missing column `", unit_id, "` or `", time_id,
+             "`.", call. = FALSE)
+    }
+
+    lag.k <- a_pm$lag %||% 0L
+    leads <- a_pm$lead %||% 0L
+    lead.max <- max(leads, na.rm = TRUE)
+
+    ## Pick the matched-set list.
+    ms_names <- names(pm)
+    if (is.null(qoi)) {
+        if (length(ms_names) == 1L) {
+            qoi <- ms_names[1L]
+        } else if ("att" %in% ms_names) {
+            qoi <- "att"
+        } else {
+            stop("`pm` carries multiple matched-set lists; specify ",
+                 "qoi = 'att' or 'atc'.", call. = FALSE)
+        }
+    }
+    ms <- pm[[qoi]]
+    if (is.null(ms)) {
+        stop("`pm` does not carry qoi = '", qoi, "'.", call. = FALSE)
+    }
+
+    ## Panel axes --- sort to match panelView's internal ordering.
+    units <- sort(unique(pd[[unit_id]]))
+    times <- sort(unique(pd[[time_id]]))
+
+    ## Mirror panelView's pre-plot drop: a unit whose outcome or
+    ## treatment column is entirely NA never reaches the plot, so its
+    ## column in the mask is stale and the strict-alignment guard
+    ## would fire. Drop those units up front so the returned mask
+    ## aligns with whatever panelview() will render.
+    outcome   <- a_pm$outcome   %||% a_pd$outcome
+    treatment <- a_pm$treatment %||% a_pd$treatment
+    drop_cols <- function(col) {
+        if (is.null(col) || !col %in% names(pd)) return(character(0))
+        ok <- tapply(!is.na(pd[[col]]), pd[[unit_id]], any)
+        as.character(names(ok)[!ok])
+    }
+    dropped <- unique(c(drop_cols(outcome), drop_cols(treatment)))
+    if (length(dropped) > 0L) {
+        units <- units[!as.character(units) %in% dropped]
+    }
+
+    TT <- length(times); N <- length(units)
+    out <- matrix(FALSE, nrow = TT, ncol = N,
+                  dimnames = list(as.character(times),
+                                  as.character(units)))
+    if (TT == 0L || N == 0L) return(out)
+
+    row_idx <- stats::setNames(seq_len(TT), as.character(times))
+    col_idx <- stats::setNames(seq_len(N),  as.character(units))
+    times_num <- suppressWarnings(as.numeric(names(row_idx)))
+    times_numeric <- !anyNA(times_num)
+
+    set_keys <- names(ms)
+    if (length(set_keys) == 0L) return(out)
+
+    for (k in seq_along(ms)) {
+        key <- set_keys[k]
+        ## "<treated_unit>.<treated_time>" --- split on the LAST dot
+        ## so unit ids that contain a dot still parse correctly.
+        dot <- regexpr("\\.[^.]*$", key)
+        if (dot < 1L) next
+        treated_unit <- substr(key, 1L, dot - 1L)
+        treated_time <- as.numeric(substr(key, dot + 1L, nchar(key)))
+        if (!is.finite(treated_time)) next
+
+        ## Time window for this event: matching support + outcome
+        ## leads. Sequence in the original time scale; subset to
+        ## times actually present.
+        t_lo <- treated_time - lag.k
+        t_hi <- treated_time + lead.max
+        if (times_numeric) {
+            t_seq <- seq(t_lo, t_hi)
+            t_keys <- as.character(t_seq[t_seq %in% times_num])
+        } else {
+            ## non-numeric times: fall back to all times in the panel
+            ## whose character form matches the integer sequence.
+            t_keys <- as.character(seq(t_lo, t_hi))
+            t_keys <- t_keys[t_keys %in% names(row_idx)]
+        }
+        if (length(t_keys) == 0L) next
+        rows <- row_idx[t_keys]
+
+        ## Units in this set: treated + (optionally) positive-weight controls.
+        keep_units <- character(0)
+        if ("treated" %in% include) {
+            keep_units <- c(keep_units, treated_unit)
+        }
+        if ("controls" %in% include) {
+            ctrls <- as.character(ms[[k]])
+            w <- attr(ms[[k]], "weights")
+            if (!is.null(w)) {
+                wnm <- names(w)
+                if (!is.null(wnm) && length(wnm) == length(ctrls)) {
+                    ctrls <- wnm[w > weight.threshold]
+                } else {
+                    ctrls <- ctrls[w > weight.threshold]
+                }
+            }
+            keep_units <- c(keep_units, ctrls)
+        }
+        keep_units <- unique(keep_units)
+        keep_units <- keep_units[keep_units %in% names(col_idx)]
+        if (length(keep_units) == 0L) next
+        cols <- col_idx[keep_units]
+
+        out[rows, cols] <- TRUE
+    }
+
+    out
+}
+
+`%||%` <- function(x, y) if (is.null(x)) y else x

--- a/R/plot-treat.R
+++ b/R/plot-treat.R
@@ -87,8 +87,14 @@
 
             ## theme-dependent binary palette (control / treated-pre / treated-post)
             if (identical(theme, "red")) {
-                pv.ctl  <- "grey85"
-                pv.tpre <- "grey50"
+                ## Under Control = dusty pink in the same hue family as the
+                ## "#B83A4B" treatment, so the two cohort-window colors
+                ## share a story (cohort = warm) while the unused / faded
+                ## cells stay grey. Earlier shades of grey collided with
+                ## the unused-cell default grey85, making the two control
+                ## bands indistinguishable.
+                pv.ctl  <- "#E8B5BC"
+                pv.tpre <- "grey45"
                 pv.tpst <- "#B83A4B"
             } else {
                 pv.ctl  <- "#B0C4DE"
@@ -184,7 +190,7 @@
                 if (by.timing == TRUE) {
                     co.seq <- which(unit.type == 1) ## unit.type: 1 for control; 2 for treated; 3 for reversal
                     tr.seq <- setdiff(1:N, co.seq)
-                    dataT0 <- cbind.data.frame(tr.seq, T0, co.total) 
+                    dataT0 <- cbind.data.frame(tr.seq, T0, co.total)
                     names(dataT0) <- c("id", "T0", "co.total")
                     dataT0 <- dataT0[order(dataT0[, "T0"], dataT0[, "co.total"], dataT0[, "id"]),] ## order of by.timing
 
@@ -193,6 +199,12 @@
 
                     m <- as.matrix(m[,missing.seq])
                     id <- id[missing.seq]
+                    ## Keep the sample column ordering in sync with m:
+                    ## by.timing reshuffles units, and the sample matrix was
+                    ## originally indexed in raw-id order so it has to follow.
+                    if (!is.null(sample)) {
+                        sample <- sample[, missing.seq, drop = FALSE]
+                    }
 
                 }
 
@@ -201,24 +213,78 @@
         }
 
         ## user-defined color setting and legend
+        ##
+        ## color = NULL                   --- theme defaults for used cells +
+        ##                                    sample-mode defaults for unused
+        ## color = c(...) (unnamed)       --- positional override of the used
+        ##                                    palette, length must equal the
+        ##                                    active break count
+        ## color = c(name = "...", ...)   --- named override. Supported names:
+        ##     control          --- Under Control
+        ##     treated          --- Under Treatment ( = treated.post)
+        ##     treated.pre      --- Treated (Pre), three-state binary only
+        ##     missing          --- Missing observations
+        ##     unused.control   --- Not used: Under Control
+        ##     unused.treated   --- Not used: Under Treatment
+        ## Unspecified names keep their theme default.
+        user_unused <- NULL   # named character vector for unused-side slots
         if (!is.null(color)) {
-            if (treat.type == "discrete") { ## discrete treatment indicator
-                if (length(col) == length(color)) {
-                    cat(paste("Specified colors in the order of: ", paste(label, collapse = ", "), ".\n", sep = ""))
+            if (treat.type == "discrete") {
+                if (!is.null(names(color)) && any(nzchar(names(color)))) {
+                    nm <- names(color)
+                    used_names   <- c("control", "treated", "treated.pre", "missing")
+                    unused_names <- c("unused.control", "unused.treated")
+                    bad <- setdiff(nm, c(used_names, unused_names))
+                    if (length(bad) > 0L) {
+                        stop("Unknown color name(s): ",
+                             paste(bad, collapse = ", "),
+                             ". Allowed names: ",
+                             paste(c(used_names, unused_names), collapse = ", "),
+                             ".", call. = FALSE)
+                    }
+                    used_overrides <- color[intersect(nm, used_names)]
+                    user_unused    <- color[intersect(nm, unused_names)]
+
+                    if (length(used_overrides) > 0L) {
+                        ## map each label position to a name. Labels carry
+                        ## the human strings ("Under Control", etc.); map
+                        ## via the underlying breaks (-1, 0, 1, -200).
+                        label_to_name <- function(b, lab) {
+                            bi <- suppressWarnings(as.integer(as.character(b)))
+                            if (!is.na(bi)) {
+                                if (bi == -1L) return("control")
+                                if (bi == 0L  && grepl("Pre", lab))
+                                    return("treated.pre")
+                                if (bi == 0L) return("treated")
+                                if (bi == 1L) return("treated")
+                                if (bi == -200L) return("missing")
+                            }
+                            NA_character_
+                        }
+                        slot_names <- mapply(label_to_name, breaks, label,
+                                             USE.NAMES = FALSE)
+                        hit <- match(names(used_overrides), slot_names)
+                        ok  <- !is.na(hit)
+                        if (any(ok)) {
+                            col[hit[ok]] <- used_overrides[ok]
+                            cat("Set used-cell colors for: ",
+                                paste(names(used_overrides)[ok],
+                                      collapse = ", "), ".\n", sep = "")
+                        }
+                    }
+                } else if (length(col) == length(color)) {
+                    cat(paste("Specified colors in the order of: ",
+                              paste(label, collapse = ", "), ".\n", sep = ""))
                     col <- color
-                } 
-                else { 
-                    stop(paste("Length of \"color\" should be equal to ",length(col),".\n", sep=""))
+                } else {
+                    stop(paste("Length of \"color\" should be equal to ",
+                               length(col),
+                               ", or use a named vector with any of: ",
+                               "control, treated, treated.pre, missing, ",
+                               "unused.control, unused.treated.\n", sep = ""))
                 }
-            } 
-            #else {
-            #    if (length(color) != 2) {
-             #       stop(paste("Length of \"color\" should be equal to ",length(col),".\n", sep=""))
-              #  } else {
-               #     col <- color
-                #}
-            #}
-        }       
+            }
+        }
         
         if (!is.null(legend.labs)) {
             if (treat.type == "discrete") { ## discrete treatment indicator
@@ -248,17 +314,89 @@
         #else{        
         res <- c(m)
         #}
-        
+
+        ## subset sample the same way obs.missing is subset, then flatten
+        ## column-major so it lines up with c(m). sample is TRUE for cells
+        ## the estimator actually used.
+        if (!is.null(sample)) {
+            if (!identical(dim(sample), dim(obs.missing))) {
+                stop(sprintf(
+                    "\"sample\" dimensions (%d x %d) must match the panel (%d x %d).",
+                    nrow(sample), ncol(sample),
+                    nrow(obs.missing), ncol(obs.missing)
+                ))
+            }
+            sample_m <- as.matrix(sample[show, , drop = FALSE])
+        }
+
         data <- cbind.data.frame(units=units, period=period, res=res)
-      
+        if (!is.null(sample)) {
+            data$used <- c(sample_m)
+        }
+
 
         if (leave.gap == 0) {
             data <- na.omit(data)
         }
 
-        #if (treat.type == "discrete") { 
-            data[,"res"] <- as.factor(data[,"res"])
-        #}
+        ## When a sample matrix is supplied, retag unused cells with a
+        ## "u"-prefixed res key so a single fill scale and a single legend
+        ## cover both the used palette and the unused palette. Extending
+        ## breaks / col / label here keeps scale_fill_manual the source of
+        ## truth.
+        ##
+        ## Missing cells (res = "-200") are NOT retagged --- a missing cell
+        ## cannot be "used" by any estimator, so the used/unused distinction
+        ## is meaningless. Keep the single "Missing" legend entry.
+        ##
+        ## Default: control / treated unused share one grey tier, so the
+        ## legend has a single "Not used" entry. Naming `unused.control` and
+        ## `unused.treated` separately in `color` opts back into the split.
+        if (!is.null(sample)) {
+            res_chr <- as.character(data$res)
+            is_miss <- res_chr == "-200"
+
+            mc <- c("#BFBFBF", "#BFBFBF")
+            if (!is.null(user_unused) && length(user_unused) > 0L) {
+                if ("unused.control" %in% names(user_unused)) {
+                    mc[1] <- user_unused[["unused.control"]]
+                }
+                if ("unused.treated" %in% names(user_unused)) {
+                    mc[2] <- user_unused[["unused.treated"]]
+                }
+            }
+            collapse_unused <- identical(mc[1], mc[2])
+
+            if (collapse_unused) {
+                ## single "Not used" tier --- one key, one legend entry.
+                data$res <- ifelse(data$used | is_miss, res_chr, "u")
+                if ("u" %in% unique(data$res)) {
+                    breaks <- c(breaks, "u")
+                    col    <- c(col,    mc[1])
+                    label  <- c(label,  "Not used")
+                }
+            } else {
+                ## split: one unused entry per status (control / treated).
+                data$res <- ifelse(data$used | is_miss,
+                                   res_chr, paste0("u", res_chr))
+                unused_keys   <- paste0("u", as.character(breaks))
+                unused_cols   <- vapply(breaks, function(b) {
+                    bi <- suppressWarnings(as.integer(as.character(b)))
+                    if (!is.na(bi) && bi >= 0) mc[2] else mc[1]
+                }, character(1))
+                unused_labels <- paste("Not used:", label)
+                drop_miss <- unused_keys == "u-200"
+                unused_keys   <- unused_keys[!drop_miss]
+                unused_cols   <- unused_cols[!drop_miss]
+                unused_labels <- unused_labels[!drop_miss]
+                keep <- unused_keys %in% unique(data$res)
+                breaks <- c(breaks, unused_keys[keep])
+                col    <- c(col,    unused_cols[keep])
+                label  <- c(label,  unused_labels[keep])
+            }
+        }
+
+        data[,"res"] <- as.factor(data[,"res"])
         
         ## check if N >= 200
         if (dim(m)[2] >= 200) {

--- a/man/panelView.Rd
+++ b/man/panelView.Rd
@@ -22,14 +22,16 @@
             style = NULL, by.unit = FALSE, lwd = 0.2, leave.gap = FALSE,
             display.all = NULL, by.cohort = FALSE,
             collapse.history = NULL, report.missing = FALSE,
-            show.singletons = TRUE, highlight.components = TRUE,
+            show.singletons = TRUE,
+            sample = NULL, sample.sort = FALSE,
+            highlight.components = TRUE,
             layout = "fr", node.size = 3,
             show.labels = "auto", edge.color = "gray70",
             edge.alpha = NULL, edge.width = NULL,
             singleton.color = "#D7263D")
 }
 \arguments{
-  \item{data}{a data frame. The panel does not have to be balanced.}
+  \item{data}{a data frame (the panel does not have to be balanced) \emph{or} a fitted panel-estimator object of class \code{"fect"}, \code{"gsynth"}, \code{"tjbal"}, or \code{"cip"}. When a fitted object is supplied, panelview reconstructs \code{data}, \code{formula}, and \code{index} from the object's slots (\code{$Y.dat}, \code{$D.dat}, \code{$id}, \code{$rawtime}, \code{$index}, \code{$Y}, \code{$D}) and auto-pulls \code{$sample}. This removes the data-consistency burden: the rendered panel is, by construction, the one the estimator saw.}
   \item{formula}{an object of class "formula": a symbolic description of the model to be fitted. The first variable on the right-hand-side is designated as the treatment indicator if \code{ignore.treat = FALSE}. If there is not any covariates, the formula should be like \code{Y~1}, where \code{Y} is the outcome variable.}
   \item{Y}{variable name of the outcome. Ignored if \code{formula} is provided.}
   \item{D}{variable name of the treatment. Ignored if \code{formula} is provided.}
@@ -56,7 +58,7 @@
   \item{pre.post}{a logical flag indicating whether to distinguish control status of treated units from that of control units. Only used for staggered data in the treat and outcome plots.}
   \item{id}{a vector specifying units to be shown in the plot. Useful when the number of units is very large.}
   \item{show.id}{a numeric vector or sequence specifying the sorted order of units to be shown in the \code{"treat"} plot. Useful when the number of units is very large. Ignored if \code{!is.null("id")}.}
-  \item{color}{a string vector specifying color setting for the plot.}
+  \item{color}{a character vector specifying colors for the plot. An unnamed vector is treated positionally (matching the active break order). A named vector accepts any subset of: \code{"control"} (Under Control), \code{"treated"} (Under Treatment), \code{"treated.pre"} (Treated Pre, three-state binary only), \code{"missing"} (Missing observations), \code{"unused.control"} (Not used: Under Control), \code{"unused.treated"} (Not used: Under Treatment). Unspecified names keep their theme default. Default \code{NULL}.}
   \item{axis.adjust}{a logic flag indicating whether to adjust labels on the x-axis.  Useful when the class of time variable is string and there are many time periods.}
   \item{axis.lab}{a string indicating whether labels on the x- and y-axis will be shown. There are four options: \code{"both"} (default): labels on both axes will be shown; \code{"unit"}: only labels on y-axis will be shown; \code{"time"}: only labels on the x-axis will be shown; "none": no labels will be shown.}
   \item{axis.lab.gap}{a numeric vector setting the gaps between labels on the x- or y-axis for the plot. Default is \code{axis.lab.gap = c(0, 0)}, which means that all labels will be shown. Useful for datasets with large N or T.}
@@ -79,6 +81,8 @@
   \item{collapse.history}{a logical flag indicating whether to collapse units by treat history in a "treat"" plot.}
   \item{report.missing}{a logical flag indicating whether to report missingness in the included variables.}
   \item{show.singletons}{logical. If \code{TRUE} (default), singleton nodes (degree-1) are highlighted with a red outline ring. Only used when \code{type = "network"}.}
+  \item{sample}{an estimation-sample indicator. Accepts a logical \eqn{T \times N} matrix marking cells used by the estimator (\code{TRUE} = used, \code{FALSE} = not used), or a fitted object of class \code{"fect"}, \code{"gsynth"}, \code{"tjbal"}, or \code{"cip"} whose \code{$sample} slot is pulled automatically. When supplied, cells with \code{sample = FALSE} render in a faded \dQuote{Not used} variant of the palette; cells with \code{sample = TRUE} use the normal colors. The matrix is aligned to the panel by row/column names if present (extra cells in the data are padded with \code{FALSE}; extras in the sample raise an error). Default \code{NULL}.}
+  \item{sample.sort}{a logical flag. When \code{TRUE} (and a \code{sample} is supplied), units that appear in the estimation sample (\code{colSums(sample) > 0}) are sorted above units that do not. Combines with \code{by.timing} as primary/secondary sort keys: \code{sample.sort = TRUE} (primary) + \code{by.timing = TRUE} (secondary by treatment timing). Default \code{FALSE}.}
   \item{highlight.components}{logical. If \code{TRUE} (default), connected components are shaded with convex hulls. Only used when \code{type = "network"}.}
   \item{layout}{character. Layout algorithm for the bipartite graph. One of \code{"fr"} (Fruchterman-Reingold, default), \code{"bipartite"}, or \code{"circle"}. Only used when \code{type = "network"}.}
   \item{node.size}{numeric. Size of nodes in the graph. Default is 3. Only used when \code{type = "network"}.}

--- a/man/panelmatch_to_sample.Rd
+++ b/man/panelmatch_to_sample.Rd
@@ -1,0 +1,68 @@
+\name{panelmatch_to_sample}
+\alias{panelmatch_to_sample}
+\title{Convert a PanelMatch object to a panelView sample mask}
+\description{
+Walks a \code{PanelMatch} object's matched sets and returns a logical
+\eqn{T \times N} matrix marking the panel cells used in estimation,
+suitable for passing as \code{sample=} to \code{\link{panelview}}. For
+each treated event, the treated unit and each matched control
+(positive weight) are marked \code{TRUE} over
+\eqn{[t-\code{lag},\,t+\max(\code{lead})]} --- the lag window covers
+the matching support and the lead window covers the outcome leads
+PanelMatch uses on the LHS, so within each event the light-blue
+pre-period and dark-blue post-onset cells render as one contiguous
+band. \code{panelview()} also accepts a \code{PanelMatch} object
+directly via \code{sample=}; in that case this helper is called
+internally with default arguments.
+}
+\usage{
+panelmatch_to_sample(pm, pd, qoi = NULL,
+                     include = c("treated", "controls"),
+                     weight.threshold = 0)
+}
+\arguments{
+  \item{pm}{A \code{PanelMatch} object (CRAN package \pkg{PanelMatch}).}
+  \item{pd}{The \code{PanelData} object passed to \code{PanelMatch()},
+    or any \code{data.frame} carrying the same \code{unit.id} and
+    \code{time.id} columns. Used to define the panel axes (sorted
+    unique units / times).}
+  \item{qoi}{One of \code{"att"}, \code{"atc"}. If \code{NULL} (default)
+    and \code{pm} carries a single matched-set list, that one is used;
+    if both are present \code{"att"} is preferred.}
+  \item{include}{Character vector. Any of \code{"treated"} (the treated
+    unit) and \code{"controls"} (matched controls). Default both.}
+  \item{weight.threshold}{Numeric. Controls with weight strictly
+    greater than this are marked. Default \code{0} keeps any positive
+    weight.}
+}
+\value{
+A logical matrix with rows = sorted unique times (rownames are
+character), columns = sorted unique units (colnames are character).
+\code{TRUE} = cell appears in at least one matched set's full window
+under the chosen \code{include} / \code{weight.threshold} rules.
+}
+\examples{
+\dontrun{
+library(PanelMatch)
+data(dem)
+pd <- PanelData(panel.data = dem, unit.id = "wbcode2",
+                time.id = "year", treatment = "dem", outcome = "y")
+pm <- PanelMatch(panel.data = pd, lag = 4,
+                 refinement.method = "mahalanobis",
+                 covs.formula = ~ I(lag(tradewb, 1:4)),
+                 qoi = "att", lead = 0:3, match.missing = TRUE)
+mask <- panelmatch_to_sample(pm, pd)
+panelview(pd, formula = y ~ dem, index = c("wbcode2", "year"),
+          type = "treat", sample = mask)
+
+## convenience: panelview() accepts the PanelMatch object directly
+panelview(pd, formula = y ~ dem, index = c("wbcode2", "year"),
+          type = "treat", sample = pm)
+}
+}
+\seealso{
+\code{\link{panelview}}
+}
+\author{
+Yiqing Xu
+}

--- a/tests/testthat/test-graph.R
+++ b/tests/testthat/test-graph.R
@@ -23,7 +23,7 @@ get_singletons <- function(result, fe_name) {
 
 test_that("network type works with balanced panel", {
     skip_if_not_installed("igraph")
-    data(turnout, package = "panelView")
+    ## turnout is lazy-loaded by library(panelView); see DESCRIPTION LazyData: true
     result <- pv(turnout, ~1, index = c("abb", "year"), type = "network")
 
     expect_true(is.list(result))
@@ -42,7 +42,7 @@ test_that("network type works with balanced panel", {
 
 test_that("graph alias works", {
     skip_if_not_installed("igraph")
-    data(turnout, package = "panelView")
+    ## turnout is lazy-loaded by library(panelView); see DESCRIPTION LazyData: true
     result <- pv(turnout, ~1, index = c("abb", "year"), type = "graph")
 
     expect_true(is.list(result))
@@ -107,7 +107,7 @@ test_that("singleton alias works", {
 
 test_that("all layout algorithms work", {
     skip_if_not_installed("igraph")
-    data(turnout, package = "panelView")
+    ## turnout is lazy-loaded by library(panelView); see DESCRIPTION LazyData: true
     for (lay in c("fr", "bipartite", "circle")) {
         result <- pv(turnout, ~1, index = c("abb", "year"),
                      type = "network", layout = lay)
@@ -124,7 +124,7 @@ test_that("all layout algorithms work", {
 
 test_that("invalid layout errors", {
     skip_if_not_installed("igraph")
-    data(turnout, package = "panelView")
+    ## turnout is lazy-loaded by library(panelView); see DESCRIPTION LazyData: true
     expect_error(
         pv(turnout, ~1, index = c("abb", "year"),
            type = "network", layout = "invalid"),
@@ -273,7 +273,7 @@ test_that("factor IDs work", {
 
 test_that("formula with variables works for network", {
     skip_if_not_installed("igraph")
-    data(turnout, package = "panelView")
+    ## turnout is lazy-loaded by library(panelView); see DESCRIPTION LazyData: true
     result <- pv(turnout, turnout ~ policy_edr,
                  index = c("abb", "year"), type = "network")
 
@@ -287,7 +287,7 @@ test_that("formula with variables works for network", {
 # -----------------------------------------------------------------------
 
 test_that("existing treat type unaffected", {
-    data(turnout, package = "panelView")
+    ## turnout is lazy-loaded by library(panelView); see DESCRIPTION LazyData: true
     expect_no_error(
         pv(turnout, turnout ~ policy_edr, index = c("abb", "year"),
            type = "treat")
@@ -295,7 +295,7 @@ test_that("existing treat type unaffected", {
 })
 
 test_that("existing missing type unaffected", {
-    data(turnout, package = "panelView")
+    ## turnout is lazy-loaded by library(panelView); see DESCRIPTION LazyData: true
     expect_no_error(
         pv(turnout, turnout ~ 1, index = c("abb", "year"),
            type = "missing")
@@ -303,7 +303,7 @@ test_that("existing missing type unaffected", {
 })
 
 test_that("existing outcome type unaffected", {
-    data(turnout, package = "panelView")
+    ## turnout is lazy-loaded by library(panelView); see DESCRIPTION LazyData: true
     expect_no_error(
         pv(turnout, turnout ~ policy_edr, index = c("abb", "year"),
            type = "outcome")
@@ -311,7 +311,7 @@ test_that("existing outcome type unaffected", {
 })
 
 test_that("existing bivariate type unaffected", {
-    data(turnout, package = "panelView")
+    ## turnout is lazy-loaded by library(panelView); see DESCRIPTION LazyData: true
     expect_no_error(
         pv(turnout, turnout ~ policy_edr, index = c("abb", "year"),
            type = "bivariate")

--- a/tutorial/01-treat.Rmd
+++ b/tutorial/01-treat.Rmd
@@ -139,6 +139,19 @@ panelview(Capacity ~ demo + lnpop + lngdp,
           axis.lab.gap = c(2, 10), theme = "red")
 ```
 
+If the dusty pink for "Under Control" feels too warm, swap in a neutral
+light grey via the named `color` argument so the dark-red treatment
+cells become the only chromatic element. All other palette slots
+inherit the red theme's defaults:
+
+```{r treat2-theme-red-grey, fig.height=10}
+panelview(Capacity ~ demo + lnpop + lngdp,
+          data = capacity, index = c("ccode", "year"),
+          main = "Democracy and State Capacity",
+          axis.lab.gap = c(2, 10), theme = "red",
+          color = c(control = "grey85"))
+```
+
 ## Customizing with ggplot2 syntax
 
 `panelview()` returns a `ggplot` object for single-panel plots, so any
@@ -273,3 +286,277 @@ panelview(Capacity ~ polity2 + lngdp,
           color = c("yellow", "orange", "red", "purple", "brown"),
           background = "white")
 ```
+
+## Overlaying the estimation sample {#sec-sample}
+
+For the treatment plot (`type = "treat"`), **panelView** can shade
+the cells the estimator actually used in grey. This shows what
+fraction of the panel a given method relies on, and which units or
+periods are dropped. The feature works for the imputation estimators
+**fect**, **gsynth**, and **tjbal**, and for the matching estimator
+**PanelMatch**.
+
+The example data in this section is the `dem` panel from
+**PanelMatch**: 175 countries from 1960 to 2010, with a binary
+democracy indicator and per-capita income (`y`) as outcome. The data
+are already in long format. `PanelMatch::PanelData()` attaches
+treatment, outcome, unit-id, and time-id metadata to the data.frame
+so that subsequent `PanelMatch()` calls can resolve those columns
+without restating them; it does not reshape the data. `fect()` and
+`panelview()` treat the result, `pd`, as an ordinary data.frame.
+
+```{r treat-data-setup, message=FALSE, warning=FALSE}
+library(PanelMatch); library(fect); library(panelView)
+data(dem)
+pd <- PanelMatch::PanelData(panel.data = dem, unit.id = "wbcode2",
+                            time.id = "year", treatment = "dem",
+                            outcome = "y")
+```
+
+### Baseline: pre-fit treatment plot
+
+Before fitting any estimator, the standard treatment plot shows the
+status of every cell:
+
+```{r treat-prefit, fig.height=10}
+panelview(y ~ dem, data = pd, index = c("wbcode2", "year"),
+          type = "treat", by.timing = TRUE, axis.lab = "off")
+```
+
+By default, dropped controls and dropped treated units share a single
+neutral grey. The control vs. treated distinction is already shown by
+the colors of used cells, so a single unused color keeps the main
+contrast in the figure between what the estimator used and what it
+did not. A two-color split for unused cells is available as an option;
+the PanelMatch section below shows when it is useful.
+
+### PanelMatch
+
+Imai, Kim, and Wang's `PanelMatch` matches each treated event to a
+set of control units on the basis of pre-treatment history. Its
+output is a list of matched sets rather than a fitted panel of
+counterfactuals. The helper `panelmatch_to_sample()` turns those
+matched sets into a $T \times N$ logical matrix that `panelview()`
+can shade. It reads only the public fields of `PanelMatch`
+(`pm$att`, `pm$atc`, and the `unit.id`, `time.id`, `lag`, `lead`
+attributes), so no changes to `PanelMatch` are needed.
+
+Run `PanelMatch` on the same `pd`:
+
+```{r treat-pm-setup, message=FALSE}
+pm <- PanelMatch(panel.data = pd, lag = 4,
+                 refinement.method = "mahalanobis",
+                 covs.formula = ~ I(lag(tradewb, 1:4)),
+                 size.match = 5,
+                 qoi = "att", lead = 0:3, match.missing = TRUE)
+```
+
+#### Pass the matched-set object directly
+
+```{r treat-pm-direct, fig.height=10}
+panelview(data = pd, formula = y ~ dem,
+          index = c("wbcode2", "year"), type = "treat",
+          by.timing = TRUE,
+          sample = pm,
+          main = "PanelMatch mask: full window [t-4, t+3]",
+          axis.lab = "off")
+```
+
+`panelview()` recognises a `PanelMatch` object and calls
+`panelmatch_to_sample()` automatically. The helper marks the window
+$[t-\text{lag},\,t+\max(\text{lead})]$ around each treated event $t$:
+the lag part covers periods used for matching, the lead part covers
+periods on which outcomes are evaluated. Within each event the
+light-blue pre-period and dark-blue post-onset cells therefore appear
+as one continuous bright band.
+
+Bright cells appear in at least one matched-set window. Grey cells
+fall outside every window. The grey area has several distinct
+sources: never-treated countries that never served as a matched
+control under this refinement; treated countries whose event window
+extends past the start or end of the panel; and periods of in-sample
+units that sit outside any nearby event.
+
+#### Split unused into control and treated
+
+To separate dropped controls from dropped treated units in the
+figure, pass different colors to `unused.control` and
+`unused.treated`:
+
+```{r treat-pm-split, fig.height=10}
+panelview(data = pd, formula = y ~ dem,
+          index = c("wbcode2", "year"), type = "treat",
+          by.timing = TRUE, sample = pm,
+          color = c(unused.control = "#D9D9D9",
+                    unused.treated = "#7A7A7A"),
+          axis.lab = "off")
+```
+
+The legend now shows "Not used: Under Control" and "Not used: Under
+Treatment" as two entries instead of one. Setting both colors to the
+same value collapses them back to a single "Not used" entry. Under
+PanelMatch both kinds are visible: the light-grey rows are
+never-democratised countries that never served as a matched control
+under this refinement, and the darker-grey rows are always-democratised
+countries that had no valid event to match.
+
+#### Customise the full palette
+
+All five used-cell colors are controlled through the same `color =`
+argument, which accepts a named vector. Any name not supplied keeps
+its theme default:
+
+```{r treat-pm-color, fig.height=10}
+panelview(data = pd, formula = y ~ dem,
+          index = c("wbcode2", "year"), type = "treat",
+          by.timing = TRUE, sample = pm,
+          color = c(control        = "#A8C686",
+                    treated        = "#D87C2A",
+                    missing        = "white",
+                    unused.control = "#F0E0CC",
+                    unused.treated = "#F0E0CC"),
+          axis.lab = "off")
+```
+
+Allowed names are `control`, `treated`, `treated.pre` (three-state
+binary only), `missing`, `unused.control`, and `unused.treated`. An
+unnamed positional vector is also accepted, preserving the older
+`color = c("#color1", "#color2", ...)` form.
+
+To change how matched sets are turned into the mask, call
+`panelmatch_to_sample(pm, pd)` directly. Useful arguments are
+`include` (limit the mask to treated units or matched controls only),
+`weight.threshold` (set the cutoff for positive weights when the
+refinement returns continuous weights), and `qoi = "atc"` (use the
+ATC matched sets when `pm` carries both).
+
+#### A wider matching spec
+
+Doubling the matching window to `lag = 8` and extending the outcome
+window to `lead = 0:6` widens each event's bright band from 8 cells
+to 15. It also drops events too close to either edge of the panel:
+events before 1968 have no $[t-8, t-1]$ history, and events after 2004
+have no $[t, t+6]$ leads.
+
+```{r treat-pm-wide, fig.height=10, message=FALSE}
+pm_wide <- PanelMatch(panel.data = pd, lag = 8,
+                      refinement.method = "mahalanobis",
+                      covs.formula = ~ I(lag(tradewb, 1:8)),
+                      size.match = 5,
+                      qoi = "att", lead = 0:6, match.missing = TRUE)
+panelview(data = pd, formula = y ~ dem,
+          index = c("wbcode2", "year"), type = "treat",
+          by.timing = TRUE, sample = pm_wide,
+          main = "PanelMatch mask: lag = 8, lead = 0:6",
+          axis.lab = "off")
+```
+
+### Imputation estimators (fect / gsynth)
+
+```{r treat-fit-setup, message=FALSE, warning=FALSE}
+fit <- fect(y ~ dem, data = pd, index = c("wbcode2", "year"),
+            method = "ife", r = 1, se = FALSE, CV = FALSE,
+            min.T0 = 2, na.rm = TRUE)
+```
+
+#### Pass the fitted object directly
+
+```{r treat-fit-1, fig.height=10}
+panelview(fit, type = "treat", by.timing = TRUE,
+          axis.lab = "off", display.all = TRUE)
+```
+
+No `data`, no `formula`, no `index` is required: `panelview()` reads
+them from the fit object. This is the simplest call because the
+figure shows exactly the panel the estimator used; the data shown in
+the plot cannot differ from the data used in estimation.
+
+Reading the figure from top to bottom: a grey "Not used" band of
+always-treated countries (democratic since 1960, with no control
+periods for fect to use) and a smaller number of never-treated
+countries whose outcome is too sparse to fit a counterfactual; then
+a dark-blue staircase of in-sample treated units ordered by year of
+transition, with light-blue cells marking their pre-transition years;
+and finally a light-blue block of never-democratised in-sample
+controls. White cells are originally missing outcomes.
+
+#### Red theme
+
+`theme = "red"` switches to a higher-contrast palette intended for
+print:
+
+```{r treat-fit-red, fig.height=10}
+panelview(fit, type = "treat", by.timing = TRUE,
+          theme = "red", axis.lab = "off", display.all = TRUE)
+```
+
+The red theme uses dusty pink (`#E8B5BC`) for "Under Control" and
+dark red (`#B83A4B`) for "Under Treatment". Cells in either treatment
+state share a warm hue; grey "Not used" cells sit visually apart.
+White cells indicate original missingness.
+
+To put the in-sample band at the top of the figure instead of the
+dropped band, set `sample.sort = TRUE`. Combined with `by.timing`,
+the four options cover the common row orderings:
+
+| `by.timing` | `sample.sort` | Row order |
+|---|---|---|
+| `FALSE` | `FALSE` | alphabetical / natural order |
+| `TRUE`  | `FALSE` | sorted by treatment timing only (default for fits) |
+| `FALSE` | `TRUE`  | in-sample first, out-of-sample below |
+| `TRUE`  | `TRUE`  | in-sample first, by treatment timing within |
+
+#### A stricter spec drops more units
+
+The shading is also useful for checking how sensitive the in-sample
+set is to specification choices. Raising `min.T0` from 2 to 10
+requires every kept unit to have at least 10 untreated periods; about
+14 more countries fail this requirement and the "Not used" band
+widens accordingly:
+
+```{r treat-fit-strict, fig.height=10, message=FALSE, warning=FALSE}
+fit_strict <- fect(y ~ dem, data = pd, index = c("wbcode2", "year"),
+                   method = "ife", r = 1, se = FALSE, CV = FALSE,
+                   min.T0 = 10, na.rm = TRUE)
+panelview(fit_strict, type = "treat", by.timing = TRUE,
+          axis.lab = "off", display.all = TRUE)
+```
+
+The in-sample share of cells drops from about 56% to about 51%.
+The "Not used" band at the top thickens compared with `fit` above.
+Originally missing cells remain white.
+
+#### Pass `sample = fit` alongside explicit data + formula
+
+The original `(data, formula, index)` form still works, and
+`sample =` accepts the fit object directly. The figure matches the
+fit-as-input view above. This form is useful when the original `data`
+object is not loaded in the current session --- for example, after
+reading a saved `.rds` fit:
+
+```{r treat-sample-explicit, eval=FALSE}
+panelview(y ~ dem, data = pd, index = c("wbcode2", "year"),
+          type = "treat", by.timing = TRUE,
+          sample = fit,
+          axis.lab = "off")
+```
+
+`sample =` accepts any `fect`, `gsynth`, or `tjbal` fit that
+exposes a `$sample` field; the same call works across the three
+packages. A logical $T \times N$ matrix can also be passed directly,
+which makes the feature available to custom estimators.
+
+**Alignment by name.** The `sample` matrix and the panel data must
+agree on which units and times appear. `panelview()` follows two
+asymmetric rules:
+
+- *Data has units or periods the sample does not.* The extra cells
+  are filled with `FALSE`. This is useful when the estimator was fit
+  on a subset of a larger panel; the extra units appear in the
+  "Not used" band.
+- *Sample has units or periods the data does not.* `panelview()`
+  stops with an error that lists the mismatched cells. This usually
+  means the sample is stale or came from a different fit.
+
+If `sample` has `rownames` and `colnames`, those are used to align by
+name. A bare matrix without dimnames is aligned by position.

--- a/tutorial/aa-changelog.Rmd
+++ b/tutorial/aa-changelog.Rmd
@@ -1,5 +1,13 @@
 # Changelog {#sec-changelog .unnumbered}
 
+## v1.3.3
+
+(2026-05-19)
+
+* New `sample =` overlay on `panelview(type = "treat")`: shades out-of-sample cells in faded "Not used" colors. Accepts a logical T x N matrix, a `fect` / `gsynth` / `tjbal` fit (auto-pulls `$sample`), or a `PanelMatch` object (via new `panelmatch_to_sample(pm, pd)` helper).
+* New `panelview(fit)` entry-point: reconstructs `data`, `formula`, `index`, and `$sample` from a fit's slots; `sample.sort = TRUE` puts in-sample units on top.
+* `color` accepts a named vector with slots `control`, `treated`, `treated.pre`, `missing`, `unused.control`, `unused.treated`. Default collapses `unused.control` and `unused.treated` to a single grey "Not used" tier; assign distinct values to opt into the per-status split.
+
 ## v1.3.2
 
 (2026-05-14)


### PR DESCRIPTION
## Summary

v1.3.3 (development): adds a `sample =` overlay to `panelview(type = "treat")` that shades out-of-sample cells in grey, plus a `panelview(fit)` direct-call entry-point.

## API

```r
panelview(fit)                                    # direct-call
panelview(fit, type = "treat", by.timing = TRUE,  # primary in-sample,
          sample.sort = TRUE)                     # secondary timing
panelview(data, formula, index,                   # explicit form (legacy + new)
          sample = fit,                           # logical T x N OR a fit
          sample.sort = TRUE,
          color = c(control = ..., unused.treated = ..., ...))
```

`sample =` accepts:

- a logical $T \times N$ matrix
- a fitted `fect` / `gsynth` / `tjbal` / `cip` object (auto-pulls `$sample`)
- a `PanelMatch` object (via new `panelmatch_to_sample()` helper, which uses only public `pm$att` / `pm$atc` slots and `unit.id` / `time.id` / `lag` / `lead` attributes; no PanelMatch modification required)

`panelview(fit)` direct-call reconstructs `(data, formula, index)` from the fit's slots. New helper `R/fit_to_panel.R::.pv_from_fit()`; prefers `fit$data.long` when available, falls back to matrix reconstruction with all-NA-unit pre-drop.

`color =` accepts a named vector with slots `control`, `treated`, `treated.pre`, `missing`, `unused.control`, `unused.treated`. Default collapses `unused.control` and `unused.treated` to a single grey "Not used" entry; assigning distinct values opts into the per-status split.

`sample.sort = TRUE/FALSE` combines orthogonally with `by.timing` for a 2x2 of row orderings.

Sample-data alignment: by `match()` on dimnames when present, by position otherwise. Hard error on sample-side extras; pad with FALSE on data-side extras.

## Visual

Red theme `pv.ctl` switched to dusty pink `#E8B5BC` so used vs unused are distinguishable. `Missing` stays a single category regardless of `sample` value.

## Tutorial

New "Overlaying the estimation sample" section in `01-treat.Rmd`, organised by estimator family: PanelMatch first (both unused buckets visibly populated, good for demoing the split-color option), then imputation estimators (`fect` / `gsynth`). Uses the `dem` panel from PanelMatch throughout.

## Misc

- DESCRIPTION bump to 1.3.3, Date 2026-05-19.
- NAMESPACE: `importFrom("utils", "head")` for `.pv_from_fit`.
- `man/panelView.Rd` documents `data` as polymorphic; adds `sample` / `sample.sort`.
- New `man/panelmatch_to_sample.Rd`.
- `test-graph.R`: drop misleading `data(turnout, ...)` calls. `turnout` is lazy-loaded via DESCRIPTION's `LazyData: true`; the calls were emitting "data set 'turnout' not found" warnings even though the data was available.
- `tutorial/aa-changelog.Rmd`: v1.3.3 (development) entry.

## Test plan

- [x] `devtools::test()`: PASS, 0 warnings (was 9 `turnout`-not-found warnings before the test-graph.R cleanup).
- [x] `R CMD check --as-cran`: 0 errors / 0 warnings / 0 notes.
- [x] Tutorial book clean re-render: 7/7 chapters.
- [x] `panelview(fit)` end-to-end on `fect::hh2019`, Acemoglu d2, cip block, cip staggered: all render correctly.
- [x] PanelMatch end-to-end on `dem`: both default (collapsed grey) and split (`unused.control` + `unused.treated`) render correctly.

## Companion changes

- **fect `feat/sample-slot`** (PR [#138](https://github.com/xuyiqing/fect/pull/138)): adds `$sample` and `$data.long` slots.
- **cip `0.0.0.9003`** (already on `main` at `8f197f7`): exposes `$Y.dat / $D.dat / $id / $rawtime / $index / $Y / $D` on top of the 0.0.0.9002 `$sample` slot.

🤖 Generated with [Claude Code](https://claude.com/claude-code)